### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,5 @@ setup(name='urlnorm',
         author='Jehiah Czebotar',
         author_email='jehiah@gmail.com',
         url='http://github.com/jehiah/urlnorm',
-        download_url="http://github.com/downloads/jehiah/urlnorm/urlnorm-%s.tar.gz" % version,
+        download_url="http://github.com/downloads/jehiah/urlnorm/urlnorm-{0!s}.tar.gz".format(version),
         )

--- a/test_urlnorm.py
+++ b/test_urlnorm.py
@@ -107,7 +107,7 @@ def pytest_generate_tests(metafunc):
 def test_invalid_urls(url):
     try:
         output = urlnorm.norm(url)
-        print '%r' % output
+        print '{0!r}'.format(output)
     except urlnorm.InvalidUrl:
         return
     assert 1 == 0, "this should have raised an InvalidUrl exception"

--- a/urlnorm.py
+++ b/urlnorm.py
@@ -105,8 +105,8 @@ params_unsafe_list = ' ?=+%#;'
 qs_unsafe_list = ' ?&=+%#'
 fragment_unsafe_list = ' +%#'
 path_unsafe_list = ' /?;%+#'
-_hextochr = dict(('%02x' % i, chr(i)) for i in range(256))
-_hextochr.update(('%02X' % i, chr(i)) for i in range(256))
+_hextochr = dict(('{0:02x}'.format(i), chr(i)) for i in range(256))
+_hextochr.update(('{0:02X}'.format(i), chr(i)) for i in range(256))
 
 def unquote_path(s):
     return unquote_safe(s, path_unsafe_list)
@@ -197,19 +197,19 @@ MAX_IP=0xffffffffL
 def int2ip(ipnum):
     assert isinstance(ipnum, int)
     if MAX_IP < ipnum or ipnum < 0:
-        raise TypeError("expected int between 0 and %d inclusive" % MAX_IP)
+        raise TypeError("expected int between 0 and {0:d} inclusive".format(MAX_IP))
     ip1 = ipnum >> 24
     ip2 = ipnum >> 16 & 0xFF
     ip3 = ipnum >> 8 & 0xFF
     ip4 = ipnum & 0xFF
-    return "%d.%d.%d.%d" % (ip1, ip2, ip3, ip4)
+    return "{0:d}.{1:d}.{2:d}.{3:d}".format(ip1, ip2, ip3, ip4)
 
 def norm_netloc(scheme, netloc):
     if not netloc:
         return netloc
     match = _server_authority.match(netloc)
     if not match:
-        raise InvalidUrl('no host in netloc %r' % netloc)
+        raise InvalidUrl('no host in netloc {0!r}'.format(netloc))
 
     userinfo, host, port = match.groups()
     # catch a few common errors:
@@ -217,7 +217,7 @@ def norm_netloc(scheme, netloc):
         try:
             host = int2ip(int(host))
         except TypeError:
-            raise InvalidUrl('host %r does not escape to a valid ip' % host)
+            raise InvalidUrl('host {0!r} does not escape to a valid ip'.format(host))
     if host[-1] == '.':
         host = host[:-1]
 
@@ -227,9 +227,9 @@ def norm_netloc(scheme, netloc):
         authority = '.'.join(subdomains)
 
     if userinfo:
-        authority = "%s@%s" % (userinfo, authority)
+        authority = "{0!s}@{1!s}".format(userinfo, authority)
     if port and port != _default_port.get(scheme, None):
-        authority = "%s:%s" % (authority, port)
+        authority = "{0!s}:{1!s}".format(authority, port)
     return authority
 
 
@@ -238,7 +238,7 @@ def _idn(subdomain):
         try:
             subdomain = subdomain.decode('idna')
         except UnicodeError:
-            raise InvalidUrl('Error converting subdomain %r to IDN' % subdomain)
+            raise InvalidUrl('Error converting subdomain {0!r} to IDN'.format(subdomain))
     return subdomain
 
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:urlnorm?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:urlnorm?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
